### PR TITLE
Using SKIE

### DIFF
--- a/DiceRoller/androidApp/src/main/kotlin/com/google/samples/apps/diceroller/DiceViewModel.kt
+++ b/DiceRoller/androidApp/src/main/kotlin/com/google/samples/apps/diceroller/DiceViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 
 class DiceViewModel(
     private val roller: DiceRoller,
@@ -42,7 +43,7 @@ class DiceViewModel(
         number: Int,
         sides: Int,
         unique: Boolean,
-    ) = settingsRepository.saveSettings(number, sides, unique)
+    ) = viewModelScope.launch { settingsRepository.saveSettings(number, sides, unique) }
 
     fun rollDice() {
         // Ignore attempted rolls before settings are available

--- a/DiceRoller/build.gradle.kts
+++ b/DiceRoller/build.gradle.kts
@@ -20,7 +20,6 @@ plugins {
     alias(libs.plugins.kotlin.cocoapods) apply false
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.ksp) apply false
-    alias(libs.plugins.nativecoroutines) apply false
 }
 
 tasks.register<Delete>("clean") {

--- a/DiceRoller/gradle/libs.versions.toml
+++ b/DiceRoller/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ minSdk = "24"
 androidx-core = "1.10.1"
 androidx-lifecycle = "2.6.1"
 activityCompose = "1.7.2"
+skie = "0.4.19"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -19,7 +20,7 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-cocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
-nativecoroutines = { id = "com.rickclephas.kmp.nativecoroutines", version.ref = "nativecoroutines" }
+skie = { id = "co.touchlab.skie", version.ref = "skie" }
 
 [libraries]
 androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }

--- a/DiceRoller/iosApp/Podfile
+++ b/DiceRoller/iosApp/Podfile
@@ -2,5 +2,4 @@ target 'iosApp' do
   use_frameworks!
   platform :ios, '14.1'
   pod 'shared', :path => '../shared'
-  pod 'KMPNativeCoroutinesAsync', '1.0.0-ALPHA-10'
 end

--- a/DiceRoller/iosApp/Podfile.lock
+++ b/DiceRoller/iosApp/Podfile.lock
@@ -1,27 +1,16 @@
 PODS:
-  - KMPNativeCoroutinesAsync (1.0.0-ALPHA-10):
-    - KMPNativeCoroutinesCore (= 1.0.0-ALPHA-10)
-  - KMPNativeCoroutinesCore (1.0.0-ALPHA-10)
   - shared (1.0)
 
 DEPENDENCIES:
-  - KMPNativeCoroutinesAsync (= 1.0.0-ALPHA-10)
   - shared (from `../shared`)
-
-SPEC REPOS:
-  trunk:
-    - KMPNativeCoroutinesAsync
-    - KMPNativeCoroutinesCore
 
 EXTERNAL SOURCES:
   shared:
     :path: "../shared"
 
 SPEC CHECKSUMS:
-  KMPNativeCoroutinesAsync: c941aeffc6fef5ab52fa6448221d130c050a9574
-  KMPNativeCoroutinesCore: 826573240f36e70f257c5215acab10a72b05ba82
   shared: d3e936b2c1df570cf43bf984e725cd24b68be937
 
-PODFILE CHECKSUM: b69254d89a5e04a64d7a1076a395426a967d0720
+PODFILE CHECKSUM: cb976e7e275a85ac0f87a2394c4de9268ead2adf
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.1

--- a/DiceRoller/iosApp/iosApp/SettingsViewModel.swift
+++ b/DiceRoller/iosApp/iosApp/SettingsViewModel.swift
@@ -16,7 +16,7 @@
 
 import shared
 import Combine
-import KMPNativeCoroutinesAsync
+import UIKit
 
 @MainActor
 final class SettingsViewModel: ObservableObject {
@@ -47,22 +47,19 @@ final class SettingsViewModel: ObservableObject {
     private var currentSettings: DiceSettings? = nil
 
     func startObservingSettings() async {
-        do {
-            let stream = asyncSequence(for: repository.settings)
-            for try await settings in stream {
-                self.diceCount = Int(settings.diceCount)
-                self.sideCount = Int(settings.sideCount)
-                self.uniqueRollsOnly = settings.uniqueRollsOnly
-                self.rollButtonLabel = String.localizedStringWithFormat(NSLocalizedString("game_roll_button", comment: ""), settings.diceCount, settings.sideCount)
-                self.currentSettings = settings
-            }
-        } catch {
-            print("Failed with error: \(error)")
-        }
+         for try await settings in repository.settings {
+             self.diceCount = Int(settings.diceCount)
+             self.sideCount = Int(settings.sideCount)
+             self.uniqueRollsOnly = settings.uniqueRollsOnly
+             self.rollButtonLabel = String.localizedStringWithFormat(NSLocalizedString("game_roll_button", comment: ""), settings.diceCount, settings.sideCount)
+             self.currentSettings = settings
+         }
     }
 
     func saveSettings() {
-        repository.saveSettings(diceCount: Int32(diceCount), sideCount: Int32(sideCount), uniqueRollsOnly: uniqueRollsOnly)
+        Task {
+            try? await repository.saveSettings(diceCount: Int32(diceCount), sideCount: Int32(sideCount), uniqueRollsOnly: uniqueRollsOnly)
+        }
     }
 
     func rollDice() {

--- a/DiceRoller/iosApp/iosApp/SettingsViewModel.swift
+++ b/DiceRoller/iosApp/iosApp/SettingsViewModel.swift
@@ -16,7 +16,7 @@
 
 import shared
 import Combine
-import UIKit
+import Foundation
 
 @MainActor
 final class SettingsViewModel: ObservableObject {
@@ -47,7 +47,7 @@ final class SettingsViewModel: ObservableObject {
     private var currentSettings: DiceSettings? = nil
 
     func startObservingSettings() async {
-         for try await settings in repository.settings {
+         for await settings in repository.settings {
              self.diceCount = Int(settings.diceCount)
              self.sideCount = Int(settings.sideCount)
              self.uniqueRollsOnly = settings.uniqueRollsOnly

--- a/DiceRoller/shared/build.gradle.kts
+++ b/DiceRoller/shared/build.gradle.kts
@@ -15,10 +15,10 @@
  */
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
-    alias(libs.plugins.nativecoroutines)
     alias(libs.plugins.ksp)
     alias(libs.plugins.kotlin.cocoapods)
     alias(libs.plugins.android.library)
+    alias(libs.plugins.skie)
 }
 
 version = "1.0"

--- a/DiceRoller/shared/src/commonMain/kotlin/com/google/samples/apps/diceroller/DiceSettingsRepository.kt
+++ b/DiceRoller/shared/src/commonMain/kotlin/com/google/samples/apps/diceroller/DiceSettingsRepository.kt
@@ -20,12 +20,8 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
-import com.rickclephas.kmp.nativecoroutines.NativeCoroutines
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
 
 class DiceSettingsRepository(
     private val dataStore: DataStore<Preferences>
@@ -36,13 +32,10 @@ class DiceSettingsRepository(
         const val DEFAULT_UNIQUE_ROLLS_ONLY = false
     }
 
-    private val scope = CoroutineScope(Dispatchers.Default)
-
     private val diceCountKey = intPreferencesKey("dice_count")
     private val sideCountKey = intPreferencesKey("side_count")
     private val uniqueRollsOnlyKey = booleanPreferencesKey("unique_rolls_only")
 
-    @NativeCoroutines
     val settings: Flow<DiceSettings> = dataStore.data.map {
         DiceSettings(
             it[diceCountKey] ?: DEFAULT_DICE_COUNT,
@@ -51,17 +44,15 @@ class DiceSettingsRepository(
         )
     }
 
-    fun saveSettings(
+    suspend fun saveSettings(
         diceCount: Int,
         sideCount: Int,
         uniqueRollsOnly: Boolean,
     ) {
-        scope.launch {
-            dataStore.edit {
-                it[diceCountKey] = diceCount
-                it[sideCountKey] = sideCount
-                it[uniqueRollsOnlyKey] = uniqueRollsOnly
-            }
+        dataStore.edit {
+            it[diceCountKey] = diceCount
+            it[sideCountKey] = sideCount
+            it[uniqueRollsOnlyKey] = uniqueRollsOnly
         }
     }
 }


### PR DESCRIPTION
Minor update of the sample to use SKIE for Flow data on iOS.

Some notes. The major change is how the Flow is accessed in Swift. It presents to Swift as an `AsyncSequence`, so we just loop over the data directly. It looks more like any other Swift dependency, without anything custom exposed.

The repository function `saveSettings` is now a `suspend` function, although that is an app architecture decision. That could remain the same as it was. However, SKIE's suspend functions can be called from any thread and support cancellation.