### PR TITLE
DiceRoller: Add R8 release config with Proguard files

### DIFF
--- a/DiceRoller/androidApp/build.gradle.kts
+++ b/DiceRoller/androidApp/build.gradle.kts
@@ -36,6 +36,25 @@ android {
         compose = true
         buildConfig = false
     }
+    buildTypes {
+        getByName("release") {
+            // Enables code shrinking, obfuscation, and optimization for only
+            // your project's release build type. Make sure to use a build
+            // variant with `isDebuggable=false`.
+            isMinifyEnabled = true
+
+            // Enables resource shrinking, which is performed by the
+            // Android Gradle plugin.
+            isShrinkResources = true
+
+            proguardFiles(
+                // Includes the default ProGuard rules files that are packaged with
+                // the Android Gradle plugin. To learn more, go to the section about
+                // R8 configuration files.
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+            )
+        }
+    }
     composeOptions {
         kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
     }


### PR DESCRIPTION
https://developer.android.com/build/shrink-code#enable