### PR TITLE
Update Fruitties complieSdk 35 to fix build failed

### DIFF
--- a/Fruitties/androidApp/build.gradle.kts
+++ b/Fruitties/androidApp/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 
 android {
     namespace = "com.example.fruitties.android"
-    compileSdk = 34
+    compileSdk = 35
     defaultConfig {
         applicationId = "com.example.fruitties.android"
         minSdk = 26


### PR DESCRIPTION
When build, this shown
```
2 issues were found when checking AAR metadata:

  1.  Dependency 'androidx.lifecycle:lifecycle-runtime-compose-android:2.9.0-alpha01' requires libraries and applications that
      depend on it to compile against version 35 or later of the
      Android APIs.

      :androidApp is currently compiled against android-34.

      Also, the maximum recommended compile SDK version for Android Gradle
      plugin 8.5.2 is 34.

      Recommended action: Update this project's version of the Android Gradle
      plugin to one that supports 35, then update this project to use
      compileSdk of at least 35.

      Note that updating a library or application's compileSdk (which
      allows newer APIs to be used) can be done separately from updating
      targetSdk (which opts the app in to new runtime behavior) and
      minSdk (which determines which devices the app can be installed
      on).

  2.  Dependency 'androidx.lifecycle:lifecycle-viewmodel-compose-android:2.9.0-alpha01' requires libraries and applications that
      depend on it to compile against version 35 or later of the
      Android APIs.

      :androidApp is currently compiled against android-34.

      Also, the maximum recommended compile SDK version for Android Gradle
      plugin 8.5.2 is 34.

      Recommended action: Update this project's version of the Android Gradle
      plugin to one that supports 35, then update this project to use
      compileSdk of at least 35.

      Note that updating a library or application's compileSdk (which
      allows newer APIs to be used) can be done separately from updating
      targetSdk (which opts the app in to new runtime behavior) and
      minSdk (which determines which devices the app can be installed
      on).

```

