### PR TITLE
Use SKIE Observing to collect state flows in SwiftUI

### DIFF
--- a/Fruitties/iosApp/iosApp/CartView.swift
+++ b/Fruitties/iosApp/iosApp/CartView.swift
@@ -21,6 +21,9 @@ import shared
 struct CartView : View {
     let mainViewModel: MainViewModel
 
+    // The ViewModel exposes a StateFlow that we access in SwiftUI with SKIE Observing.
+    // https://skie.touchlab.co/features/flows-in-swiftui
+
     @State
     private var expanded = false
 

--- a/Fruitties/iosApp/iosApp/CartView.swift
+++ b/Fruitties/iosApp/iosApp/CartView.swift
@@ -54,7 +54,8 @@ struct CartDetailsView: View {
     let mainViewModel: MainViewModel
 
     var body: some View {
-        
+
+        // https://skie.touchlab.co/features/flows-in-swiftui
         Observing(self.mainViewModel.cartUiState) { cartUIState in
             VStack {
                 ForEach(cartUIState.cartDetails, id: \.fruittie.id) { item in

--- a/Fruitties/iosApp/iosApp/ContentView.swift
+++ b/Fruitties/iosApp/iosApp/ContentView.swift
@@ -21,27 +21,22 @@ import Foundation
 struct ContentView: View {
     var mainViewModel: MainViewModel
 
-    // The ViewModel exposes a StateFlow.
-    // We collect() the StateFlow into State, which can be used in SwiftUI.
-    // https://skie.touchlab.co/features/flows-in-swiftui
-    @State
-    var homeUIState: HomeUiState = HomeUiState(fruitties: [])
-
     var body: some View {
         Text("Fruitties").font(.largeTitle).fontWeight(.bold)
         CartView(mainViewModel: mainViewModel)
-        ScrollView {
-            LazyVStack {
-                ForEach(homeUIState.fruitties, id: \.self) { value in
-                    FruittieView(fruittie: value, addToCart: { fruittie in
-                        Task {
-                            self.mainViewModel.addItemToCart(fruittie: fruittie)
-                        }
-                    })
+        // https://skie.touchlab.co/features/flows-in-swiftui
+        Observing(self.mainViewModel.homeUiState) { homeUIState in
+            ScrollView {
+                LazyVStack {
+                    ForEach(homeUIState.fruitties, id: \.self) { value in
+                        FruittieView(fruittie: value, addToCart: { fruittie in
+                            Task {
+                                self.mainViewModel.addItemToCart(fruittie: fruittie)
+                            }
+                        })
+                    }
                 }
             }
-            // https://skie.touchlab.co/features/flows-in-swiftui
-            .collect(flow: self.mainViewModel.homeUiState, into: $homeUIState)
         }
     }
 }


### PR DESCRIPTION
This commit updates the `ContentView` to use
`Observing` from the SKIE library to collect the `StateFlow` exposed by the `MainViewModel` into SwiftUI.

- This replaces the `.collect` method, which is no longer needed when using `Observing`.
- Adds a comment to reference the SKIE documentation for flows in SwiftUI.