### PR TITLE
Make mainViewModel lazy on iOS

### DIFF
--- a/Fruitties/shared/src/iosMain/kotlin/com/example/fruitties/di/viewmodel/IOSViewModelOwner.kt
+++ b/Fruitties/shared/src/iosMain/kotlin/com/example/fruitties/di/viewmodel/IOSViewModelOwner.kt
@@ -17,11 +17,13 @@ class IOSViewModelOwner(
     override val viewModelStore: ViewModelStore = ViewModelStore()
 
     // Create an instance of MainViewModel with the CreationExtras.
-    val mainViewModel: MainViewModel = ViewModelProvider.create(
-        owner = this as ViewModelStoreOwner,
-        factory = MainViewModel.Factory,
-        extras = MainViewModel.newCreationExtras(appContainer),
-    )[MainViewModel::class]
+    val mainViewModel: MainViewModel by lazy {
+        ViewModelProvider.create(
+            owner = this as ViewModelStoreOwner,
+            factory = MainViewModel.Factory,
+            extras = MainViewModel.newCreationExtras(appContainer),
+        )[MainViewModel::class]
+    }
 
     // To add more ViewModel types, add new properties for each ViewModel.
     // If we need to add a very large number of ViewModel types,


### PR DESCRIPTION
This commit changes the initialization of `mainViewModel` in `IOSViewModelOwner.kt` to be lazy. This ensures that the `MainViewModel` is only created when it is first accessed.