### PR TITLE
Prototype ViewModelStoreOwner on iOS

### DIFF
--- a/Fruitties/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/Fruitties/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557BA273AAA24004C7B11 /* Assets.xcassets */; };
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
+		2409F7722E0A082000699059 /* ViewModelStoreOwnerProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2409F7712E0A082000699059 /* ViewModelStoreOwnerProvider.swift */; };
+		2409F7762E0A0A6300699059 /* ObservableValueWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2409F7752E0A0A5F00699059 /* ObservableValueWrapper.swift */; };
 		2E8773602BC85C2400BF7C40 /* CartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E87735F2BC85C2400BF7C40 /* CartView.swift */; };
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
 /* End PBXBuildFile section */
@@ -31,6 +33,8 @@
 		058557BA273AAA24004C7B11 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		2152FB032600AC8F00CF470E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
+		2409F7712E0A082000699059 /* ViewModelStoreOwnerProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelStoreOwnerProvider.swift; sourceTree = "<group>"; };
+		2409F7752E0A0A5F00699059 /* ObservableValueWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableValueWrapper.swift; sourceTree = "<group>"; };
 		2E87735F2BC85C2400BF7C40 /* CartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartView.swift; sourceTree = "<group>"; };
 		7555FF7B242A565900829871 /* iosApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iosApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FF82242A565900829871 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -76,6 +80,8 @@
 		7555FF7D242A565900829871 /* iosApp */ = {
 			isa = PBXGroup;
 			children = (
+				2409F7752E0A0A5F00699059 /* ObservableValueWrapper.swift */,
+				2409F7712E0A082000699059 /* ViewModelStoreOwnerProvider.swift */,
 				058557BA273AAA24004C7B11 /* Assets.xcassets */,
 				7555FF82242A565900829871 /* ContentView.swift */,
 				7555FF8C242A565B00829871 /* Info.plist */,
@@ -187,6 +193,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2409F7762E0A0A6300699059 /* ObservableValueWrapper.swift in Sources */,
+				2409F7722E0A082000699059 /* ViewModelStoreOwnerProvider.swift in Sources */,
 				2E8773602BC85C2400BF7C40 /* CartView.swift in Sources */,
 				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
 				7555FF83242A565900829871 /* ContentView.swift in Sources */,

--- a/Fruitties/iosApp/iosApp/CartView.swift
+++ b/Fruitties/iosApp/iosApp/CartView.swift
@@ -19,12 +19,34 @@ import SwiftUI
 import shared
 
 struct CartView : View {
-    let cartViewModel: CartViewModel
+    /// Injects the `IOSViewModelStoreOwner` from the environment, which manages the lifecycle of `ViewModel` instances.
+    @EnvironmentObject var viewModelStoreOwner: ObservableValueWrapper<IOSViewModelStoreOwner>
 
-    // The ViewModel exposes a StateFlow that we access in SwiftUI with SKIE Observing.
-    // https://skie.touchlab.co/features/flows-in-swiftui
+    /// Injects the `AppContainer` from the environment, providing access to application-wide dependencies.
+    @EnvironmentObject var appContainer: ObservableValueWrapper<AppContainer>
 
     var body: some View {
+        /// Retrieves the `CartViewModel` instance using the `viewModelStoreOwner`.
+        /// The `CartViewModel.Factory` and `creationExtras` are provided to enable dependency
+        /// injection and proper initialization of the ViewModel with its required `AppContainer`.
+        let cartViewModelFromEnum: CartViewModel = viewModelStoreOwner.value.getViewModelWithEnum(
+            type: .cart,
+            factory: CartViewModel.companion.Factory,
+            extras: CartViewModel.companion.creationExtras(appContainer: appContainer.value)
+        ) as! CartViewModel
+        let cartViewModelWithFunctionUsingEnum: CartViewModel = viewModelStoreOwner.value.getCartViewModelWithFunctionUsingEnum(
+            factory: CartViewModel.companion.Factory,
+            extras: CartViewModel.companion.creationExtras(appContainer: appContainer.value)
+        )
+        let cartViewModelWithFunctionUsingProvider: CartViewModel = viewModelStoreOwner.value.getCartViewModelWithFunctionUsingProvider(
+            factory: CartViewModel.companion.Factory,
+            extras: CartViewModel.companion.creationExtras(appContainer: appContainer.value)
+        )
+        // Any of the 3 options work.
+//        let cartViewModel = cartViewModelFromEnum
+//        let cartViewModel = cartViewModelWithFunctionUsingEnum
+        let cartViewModel = cartViewModelWithFunctionUsingProvider
+
         // https://skie.touchlab.co/features/flows-in-swiftui
         Observing(cartViewModel.cartUiState) { cartUIState in
             VStack {

--- a/Fruitties/iosApp/iosApp/ContentView.swift
+++ b/Fruitties/iosApp/iosApp/ContentView.swift
@@ -19,15 +19,44 @@ import shared
 import Foundation
 
 struct ContentView: View {
-    var mainViewModel: MainViewModel
-    var cartViewModel: CartViewModel
+    /// Injects the `IOSViewModelStoreOwner` from the environment, which manages the lifecycle of `ViewModel` instances.
+    @EnvironmentObject var viewModelStoreOwner: ObservableValueWrapper<IOSViewModelStoreOwner>
+
+    /// Injects the `AppContainer` from the environment, providing access to application-wide dependencies.
+    @EnvironmentObject var appContainer: ObservableValueWrapper<AppContainer>
 
     var body: some View {
+        /// Retrieves the `MainViewModel` instance using the `viewModelStoreOwner`.
+        /// The `MainViewModel.Factory` and `creationExtras` are provided to enable dependency injection
+        /// and proper initialization of the ViewModel with its required `AppContainer`.
+        let mainViewModelFromEnum: MainViewModel = viewModelStoreOwner.value.getViewModelWithEnum(
+            type: .main,
+            factory: MainViewModel.companion.Factory,
+            extras: MainViewModel.companion.creationExtras(appContainer: self.appContainer.value)
+        ) as! MainViewModel
+        let mainViewModelWithFunctionUsingEnum: MainViewModel = viewModelStoreOwner.value.getMainViewModelWithFunctionUsingEnum(
+            factory: MainViewModel.companion.Factory,
+            extras: MainViewModel.companion.creationExtras(appContainer: appContainer.value)
+        )
+        let mainViewModelWithFunctionUsingProvider: MainViewModel = viewModelStoreOwner.value.getMainViewModelWithFunctionUsingProvider(
+            factory: MainViewModel.companion.Factory,
+            extras: MainViewModel.companion.creationExtras(appContainer: appContainer.value)
+        )
+        // Any of the 3 options work.
+//        let mainViewModel = mainViewModelFromEnum
+//        let mainViewModel = mainViewModelWithFunctionUsingEnum
+        let mainViewModel = mainViewModelWithFunctionUsingProvider
+
         NavigationStack {
             VStack {
                 Text("Fruitties").font(.largeTitle).fontWeight(.bold)
                 NavigationLink {
-                    CartView(cartViewModel: cartViewModel)
+                    /// Provides a new `ViewModelStoreOwner` for `CartView`, ensuring its ViewModels
+                    /// are scoped to this navigation destination and are properly managed.
+                    /// This shadows the parent's `viewModelStoreOwner` for this sub-hierarchy.
+                    ViewModelStoreOwnerProvider {
+                        CartView()
+                    }
                 } label: {
                     Observing(mainViewModel.homeUiState) { homeUIState in
                         let total = homeUIState.cartItemCount

--- a/Fruitties/iosApp/iosApp/ObservableValueWrapper.swift
+++ b/Fruitties/iosApp/iosApp/ObservableValueWrapper.swift
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Combine
+import SwiftUI
+import shared
+
+/// A generic wrapper that makes any `Value` type observable by SwiftUI.
+///
+/// Use this to wrap non-`ObservableObject` types when their changes need to update SwiftUI views.
+class ObservableValueWrapper<Value>: ObservableObject {
+
+    /// The wrapped value. Changes trigger SwiftUI view updates.
+    @Published var value: Value
+
+    /// Initializes the wrapper with an initial value.
+    init(value: Value) {
+        self.value = value
+    }
+}

--- a/Fruitties/iosApp/iosApp/ViewModelStoreOwnerProvider.swift
+++ b/Fruitties/iosApp/iosApp/ViewModelStoreOwnerProvider.swift
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import SwiftUI
+import shared
+
+/// A SwiftUI `View` that provides a `ViewModelStoreOwner` to its content.
+///
+/// Manages the lifecycle of `ViewModel` instances, scoping them to this view hierarchy.
+/// Clears the associated `ViewModelStore` when the provider disappears.
+struct ViewModelStoreOwnerProvider<Content: View>: View {
+    /// The `IOSViewModelStoreOwner` instance, wrapped for SwiftUI observability.
+    @StateObject private var viewModelStoreOwner: ObservableValueWrapper<IOSViewModelStoreOwner>
+    private let content: Content
+
+    /// Initializes the provider with its content, creating a new `IOSViewModelStoreOwner`.
+    init(@ViewBuilder content: () -> Content) {
+        _viewModelStoreOwner = StateObject(wrappedValue: ObservableValueWrapper(value: IOSViewModelStoreOwner()))
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .environmentObject(viewModelStoreOwner)
+            .onDisappear {
+                viewModelStoreOwner.value.clear()
+            }
+    }
+}

--- a/Fruitties/iosApp/iosApp/iOSApp.swift
+++ b/Fruitties/iosApp/iosApp/iOSApp.swift
@@ -19,12 +19,22 @@ import shared
 
 @main
 struct iOSApp: App {
-    let appContainer = AppContainer(factory: Factory())
+    /// The application's dependency container, wrapped for SwiftUI observation.
+    let appContainer: ObservableValueWrapper<AppContainer>
+
+    init() {
+        self.appContainer = ObservableValueWrapper<AppContainer>(
+            value: AppContainer(factory: Factory()))
+    }
+
     var body: some Scene {
         WindowGroup {
-            let iosViewModelOwner = IOSViewModelStoreOwner(appContainer: appContainer)
-            ContentView(mainViewModel: iosViewModelOwner.getMainViewModel(),
-                        cartViewModel: iosViewModelOwner.getCartViewModel())
+            /// Provides the root `ViewModelStoreOwner` to the environment, making it accessible to all child views.
+            /// Nested `ViewModelStoreOwnerProvider` instances can create additional, scoped ViewModel stores.
+            ViewModelStoreOwnerProvider {
+                ContentView()
+            }
+            .environmentObject(appContainer)
         }
     }
 }

--- a/Fruitties/shared/src/iosMain/kotlin/com/example/fruitties/di/viewmodel/IOSViewModelStoreOwner.kt
+++ b/Fruitties/shared/src/iosMain/kotlin/com/example/fruitties/di/viewmodel/IOSViewModelStoreOwner.kt
@@ -1,40 +1,107 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.fruitties.di.viewmodel
 
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.ViewModelStoreOwner
-import com.example.fruitties.di.AppContainer
+import androidx.lifecycle.viewmodel.CreationExtras
 import com.example.fruitties.viewmodel.CartViewModel
 import com.example.fruitties.viewmodel.MainViewModel
+import kotlin.reflect.KClass
+
+enum class ViewModelType {
+    MAIN,
+    CART,
+}
+
+private fun selectViewModel(type: ViewModelType): Pair<KClass<out ViewModel>, ViewModelProvider.Factory?> =
+    when (type) {
+        ViewModelType.MAIN -> MainViewModel::class to MainViewModel.Factory
+        ViewModelType.CART -> CartViewModel::class to CartViewModel.Factory
+    }
 
 /**
  * A ViewModelStoreOwner specifically for iOS.
  * This is used with from iOS with Kotlin Multiplatform (KMP).
  */
 @Suppress("unused") // Android Studio is not aware of iOS usage.
-class IOSViewModelStoreOwner(
-    val appContainer: AppContainer,
-) : ViewModelStoreOwner {
+class IOSViewModelStoreOwner : ViewModelStoreOwner {
     override val viewModelStore: ViewModelStore = ViewModelStore()
 
-    // Type-safe, but requires a new function name.
-    fun getMainViewModel(): MainViewModel =
+    // Requires a type parameter because generics do not work well with KMP and Swift.
+    // The caller must cast the ViewModel to the specific subclass.
+    fun getViewModelWithEnum(
+        type: ViewModelType,
+        factory: ViewModelProvider.Factory? = null,
+        extras: CreationExtras? = null,
+    ): ViewModel {
+        val (kClass, defaultFactory) = selectViewModel(type)
+        val provider =
+            if (factory != null) {
+                ViewModelProvider.create(this.viewModelStore, factory, extras ?: CreationExtras.Empty)
+            } else if (defaultFactory != null) {
+                ViewModelProvider.create(this.viewModelStore, defaultFactory, extras ?: CreationExtras.Empty)
+            } else {
+                ViewModelProvider.create(this)
+            }
+        return provider[kClass]
+    }
+
+    fun getMainViewModelWithFunctionUsingEnum(
+        factory: ViewModelProvider.Factory? = null,
+        extras: CreationExtras? = null,
+    ): MainViewModel =
+        getViewModelWithEnum(
+            type = ViewModelType.MAIN,
+            factory = factory ?: MainViewModel.Factory,
+            extras = extras ?: CreationExtras.Empty,
+        ) as MainViewModel
+
+    fun getMainViewModelWithFunctionUsingProvider(
+        factory: ViewModelProvider.Factory? = null,
+        extras: CreationExtras? = null,
+    ): MainViewModel =
         ViewModelProvider.create(
             owner = this as ViewModelStoreOwner,
-            factory = MainViewModel.Factory,
-            extras = MainViewModel.creationExtras(appContainer),
+            factory = factory ?: MainViewModel.Factory,
+            extras = extras ?: CreationExtras.Empty,
         )[MainViewModel::class]
 
-    fun getCartViewModel(): CartViewModel =
+    fun getCartViewModelWithFunctionUsingEnum(
+        factory: ViewModelProvider.Factory? = null,
+        extras: CreationExtras? = null,
+    ): CartViewModel =
+        getViewModelWithEnum(
+            type = ViewModelType.CART,
+            factory = factory ?: CartViewModel.Factory,
+            extras = extras ?: CreationExtras.Empty,
+        ) as CartViewModel
+
+    fun getCartViewModelWithFunctionUsingProvider(
+        factory: ViewModelProvider.Factory? = null,
+        extras: CreationExtras? = null,
+    ): CartViewModel =
         ViewModelProvider.create(
             owner = this as ViewModelStoreOwner,
-            factory = CartViewModel.Factory,
-            extras = CartViewModel.creationExtras(appContainer),
+            factory = factory ?: CartViewModel.Factory,
+            extras = extras ?: CreationExtras.Empty,
         )[CartViewModel::class]
-
-    // To add more ViewModel types, add new properties for each ViewModel.
-    // If we need to add a very large number of ViewModel types,
-    // we could consider creating a generic retrieval implementation with reflection.
 
     // If the ViewModelStoreOwner will go out of scope, we should clear the ViewModelStore.
     fun clear() {


### PR DESCRIPTION
This commit refactors the ViewModel management in the iOS app to use a more robust and flexible approach with `ViewModelStoreOwner` and dependency injection.

Key changes:

*   **Introduced `IOSViewModelStoreOwner`:**
    *   Manages the lifecycle of ViewModels.
    *   Provides methods to retrieve ViewModels using either an enum (`ViewModelType`), specific function calls, or direct `ViewModelProvider` usage.
    *   Allows passing `CreationExtras` for dependency injection into ViewModels.
*   **Created `ViewModelStoreOwnerProvider`:**
    *   A SwiftUI `View` that provides an `IOSViewModelStoreOwner` to its content via the environment.
    *   Manages the lifecycle of the `ViewModelStore`, clearing it when the provider disappears.
    *   Allows for nested providers to create scoped `ViewModelStoreOwner` instances.
*   **Implemented `ObservableValueWrapper`:**
    *   A generic wrapper to make non-`ObservableObject` types (like `IOSViewModelStoreOwner` and `AppContainer`) observable by SwiftUI.
*   **Updated ViewModels in `CartView` and `ContentView`:**
    *   ViewModels are now retrieved from the `IOSViewModelStoreOwner` injected via `@EnvironmentObject`.
    *   `AppContainer` is also injected via `@EnvironmentObject` to provide dependencies to ViewModels.
    *   `CartView` is now wrapped in its own `ViewModelStoreOwnerProvider` to scope its ViewModels.
*   **Modified `iOSApp.swift`:**
    *   Initializes and provides the root `AppContainer` and `ViewModelStoreOwnerProvider` to the main `ContentView`.

This approach improves ViewModel scoping, lifecycle management, and simplifies dependency injection for ViewModels in the iOS application.