### PR TITLE
fix: Moved `enableEdgeToEdge` before `super.onCreate`

### DIFF
--- a/Fruitties/androidApp/src/main/java/com/example/fruitties/android/MainActivity.kt
+++ b/Fruitties/androidApp/src/main/java/com/example/fruitties/android/MainActivity.kt
@@ -53,8 +53,8 @@ data class FruittieScreenKey(
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        super.onCreate(savedInstanceState)
         setContent {
             CompositionLocalProvider(
                 LocalAppContainer provides (this.applicationContext as FruittiesAndroidApp).container,


### PR DESCRIPTION
- The `enableEdgeToEdge` call should be made before `super.onCreate` in `MainActivity` to ensure that the system UI and window insets are configured before the layout is inflated.
- Also mentioned on: https://github.com/android/compose-samples/issues/1560

Source documentation:
- [developer.android.com](https://developer.android.com/reference/androidx/activity/ComponentActivity#(androidx.activity.ComponentActivity).enableEdgeToEdge(androidx.activity.SystemBarStyle,androidx.activity.SystemBarStyle))
- [code search](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:activity/activity/src/main/java/androidx/activity/EdgeToEdge.kt?q=file:androidx%2Factivity%2FEdgeToEdge.kt%20function:enableEdgeToEdge)