### PR TITLE
Disable SKIE analytics

### DIFF
--- a/Fruitties/shared/build.gradle.kts
+++ b/Fruitties/shared/build.gradle.kts
@@ -149,4 +149,8 @@ skie {
         // https://skie.touchlab.co/features/flows-in-swiftui
         enableSwiftUIObservingPreview = true
     }
+
+    analytics {
+        enabled.set(false)
+    }
 }


### PR DESCRIPTION
I think the SKIE analytics is not necessary to make a KMP app.

Follow this documentation to disable an analytics.
https://skie.touchlab.co/Analytics

>In case you do not wish to share any data with us, you can either leave just the upload disabled, or you can disable the analytics capture altogether. Replacing the disableUpload.set(true) with enabled.set(false) will disable both phases, so there will be nothing generated in the directory you just inspected. Your configuration in build.gradle.kts should look like so: