### PR TITLE
Remove double calories.

### DIFF
--- a/Fruitties/iosApp/iosApp/ui/FruittieScreen.swift
+++ b/Fruitties/iosApp/iosApp/ui/FruittieScreen.swift
@@ -50,7 +50,7 @@ struct FruittieScreen: View {
                     Text(content.fruittie.fullName)
                         .font(.title2)
                         .padding(.bottom, 5)
-                    Text("\(content.fruittie.calories) calories")
+                    Text("\(content.fruittie.calories)")
                         .font(.title3)
 
                     Spacer()


### PR DESCRIPTION
Fix #96 

If double calories remain, we had getting double amount of calories.
Remove one calorie for health.
<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-18 at 22 32 27" src="https://github.com/user-attachments/assets/62e3de47-442c-4fc4-8b63-a2bc227442e0" />
