### PR TITLE
Implement Paging3 and Remote Mediator for Fruittie list

### DIFF
--- a/Fruitties/androidApp/src/main/java/com/example/fruitties/android/ui/ErrorStateScreen.kt
+++ b/Fruitties/androidApp/src/main/java/com/example/fruitties/android/ui/ErrorStateScreen.kt
@@ -1,0 +1,38 @@
+package com.example.fruitties.android.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.example.fruitties.android.R
+
+@Composable
+fun ErrorStateItem(
+    message: String,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = message,
+            color = MaterialTheme.colorScheme.error,
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+        )
+        Button(onClick = onRetry) {
+            Text(stringResource(R.string.retry))
+        }
+    }
+}

--- a/Fruitties/androidApp/src/main/java/com/example/fruitties/android/ui/ListScreen.kt
+++ b/Fruitties/androidApp/src/main/java/com/example/fruitties/android/ui/ListScreen.kt
@@ -18,12 +18,12 @@ package com.example.fruitties.android.ui
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -31,7 +31,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -40,6 +39,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -47,12 +47,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
 import com.example.fruitties.android.LocalAppContainer
@@ -100,53 +100,83 @@ fun ListScreen(
             }
         },
     ) { paddingValues ->
-        LazyColumn(
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            contentPadding = PaddingValues(bottom = 72.dp),
-            modifier = Modifier
-                .nestedScroll(topAppBarScrollBehavior.nestedScrollConnection)
-                .padding(paddingValues)
-                .consumeWindowInsets(paddingValues),
-        ) {
-            items(
-                count = lazyPagingItems.itemCount,
-                key = lazyPagingItems.itemKey { it.id }
-            ) { index ->
-                val item = lazyPagingItems[index]
-                if (item != null) {
-                    FruittieItem(
-                        item = item,
-                        onClick = onFruittieClick,
-                        onAddToCart = viewModel::addItemToCart,
-                        modifier = Modifier.fillMaxWidth(),
+        when (lazyPagingItems.loadState.refresh) {
+            is LoadState.Loading -> {
+                LoadingIndicator(
+                    modifier = Modifier
+                        .padding(paddingValues)
+                        .fillMaxHeight()
+                        .consumeWindowInsets(paddingValues),
+                )
+            }
+            is LoadState.Error -> {
+                ErrorStateItem(
+                    message = stringResource(R.string.error_loading),
+                    onRetry = { lazyPagingItems.refresh() },
+                    modifier = Modifier
+                        .padding(paddingValues)
+                        .consumeWindowInsets(paddingValues)
+                        .padding(16.dp),
+                )
+            }
+            else -> {
+                PagingList(
+                    lazyPagingItems = lazyPagingItems,
+                    paddingValues = paddingValues,
+                    topAppBarScrollBehavior = topAppBarScrollBehavior,
+                    onFruittieClick = onFruittieClick,
+                    onAddToCart = viewModel::addItemToCart,
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PagingList(
+    lazyPagingItems: LazyPagingItems<Fruittie>,
+    paddingValues: PaddingValues,
+    topAppBarScrollBehavior: TopAppBarScrollBehavior,
+    onFruittieClick: (Fruittie) -> Unit,
+    onAddToCart: (Fruittie) -> Unit,
+) {
+    LazyColumn(
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        contentPadding = PaddingValues(bottom = 72.dp),
+        modifier = Modifier
+            .nestedScroll(topAppBarScrollBehavior.nestedScrollConnection)
+            .padding(paddingValues)
+            .consumeWindowInsets(paddingValues),
+    ) {
+        items(
+            count = lazyPagingItems.itemCount,
+            key = lazyPagingItems.itemKey { it.id },
+        ) { index ->
+            val item = lazyPagingItems[index]
+            if (item != null) {
+                FruittieItem(
+                    item = item,
+                    onClick = onFruittieClick,
+                    onAddToCart = onAddToCart,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+
+        item {
+            when (lazyPagingItems.loadState.append) {
+                is LoadState.Loading -> {
+                    LoadingIndicator(modifier = Modifier.padding(16.dp))
+                }
+                is LoadState.Error -> {
+                    ErrorStateItem(
+                        message = stringResource(R.string.error_loading_more),
+                        onRetry = { lazyPagingItems.retry() },
+                        modifier = Modifier.padding(16.dp),
                     )
                 }
-            }
-
-            item {
-                when (lazyPagingItems.loadState.append) {
-                    is LoadState.Loading -> {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(16.dp),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            CircularProgressIndicator()
-                        }
-                    }
-                    is LoadState.Error -> {
-                        Text(
-                            text = "Error loading more items",
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(16.dp),
-                            textAlign = TextAlign.Center,
-                            color = MaterialTheme.colorScheme.error,
-                        )
-                    }
-                    else -> {}
-                }
+                else -> {}
             }
         }
     }

--- a/Fruitties/androidApp/src/main/java/com/example/fruitties/android/ui/ListScreen.kt
+++ b/Fruitties/androidApp/src/main/java/com/example/fruitties/android/ui/ListScreen.kt
@@ -18,6 +18,7 @@ package com.example.fruitties.android.ui
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -27,10 +28,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -46,10 +47,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.paging.LoadState
+import androidx.paging.compose.collectAsLazyPagingItems
+import androidx.paging.compose.itemKey
 import com.example.fruitties.android.LocalAppContainer
 import com.example.fruitties.android.R
 import com.example.fruitties.model.Fruittie
@@ -64,6 +69,7 @@ fun ListScreen(
         factory = LocalAppContainer.current.mainViewModelFactory,
     ),
 ) {
+    val lazyPagingItems = viewModel.fruittiesPagingData.collectAsLazyPagingItems()
     val uiState by viewModel.homeUiState.collectAsState()
     val topAppBarScrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     Scaffold(
@@ -102,13 +108,45 @@ fun ListScreen(
                 .padding(paddingValues)
                 .consumeWindowInsets(paddingValues),
         ) {
-            items(items = uiState.fruitties, key = { it.id }) { item ->
-                FruittieItem(
-                    item = item,
-                    onClick = onFruittieClick,
-                    onAddToCart = viewModel::addItemToCart,
-                    modifier = Modifier.fillMaxWidth(),
-                )
+            items(
+                count = lazyPagingItems.itemCount,
+                key = lazyPagingItems.itemKey { it.id }
+            ) { index ->
+                val item = lazyPagingItems[index]
+                if (item != null) {
+                    FruittieItem(
+                        item = item,
+                        onClick = onFruittieClick,
+                        onAddToCart = viewModel::addItemToCart,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+
+            item {
+                when (lazyPagingItems.loadState.append) {
+                    is LoadState.Loading -> {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            CircularProgressIndicator()
+                        }
+                    }
+                    is LoadState.Error -> {
+                        Text(
+                            text = "Error loading more items",
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            textAlign = TextAlign.Center,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                    else -> {}
+                }
             }
         }
     }

--- a/Fruitties/androidApp/src/main/java/com/example/fruitties/android/ui/LoadingIndicator.kt
+++ b/Fruitties/androidApp/src/main/java/com/example/fruitties/android/ui/LoadingIndicator.kt
@@ -1,0 +1,20 @@
+package com.example.fruitties.android.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun LoadingIndicator(
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier.fillMaxWidth(),
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator()
+    }
+}

--- a/Fruitties/androidApp/src/main/res/values/strings.xml
+++ b/Fruitties/androidApp/src/main/res/values/strings.xml
@@ -24,4 +24,7 @@
     <string name="add_to_cart">Add to cart</string>
     <string name="in_cart">In cart: %1$d</string>
     <string name="cart_has_items">Cart has %1$d items</string>
+    <string name="error_loading">Failed to load items. Please check your connection and try again.</string>
+    <string name="error_loading_more">Failed to load more items</string>
+    <string name="retry">Retry</string>
 </resources>

--- a/Fruitties/iosApp/iosApp/ui/ContentView.swift
+++ b/Fruitties/iosApp/iosApp/ui/ContentView.swift
@@ -33,10 +33,9 @@ struct ContentView: View {
             factory: appContainer.value.mainViewModelFactory
         )
         NavigationStack {
-            Observing(mainViewModel.homeUiState) { homeUIState in
+            Observing(mainViewModel.fruittiesPagingData) { pagingData in
                 List {
-                    ForEach(homeUIState.fruitties, id: \.self) {
-                        value in
+                    ForEach(pagingData, id: \.self) { value in
                         HStack {
                             NavigationLink {
                                 FruittieScreen(fruittie: value)

--- a/Fruitties/shared/src/androidMain/kotlin/com/example/fruitties/di/Factory.android.kt
+++ b/Fruitties/shared/src/androidMain/kotlin/com/example/fruitties/di/Factory.android.kt
@@ -21,6 +21,7 @@ import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import com.example.fruitties.database.AppDatabase
 import com.example.fruitties.database.CartDataStore
 import com.example.fruitties.database.DB_FILE_NAME
+import com.example.fruitties.database.MIGRATION_1_2
 import kotlinx.coroutines.Dispatchers
 
 actual class Factory(
@@ -34,7 +35,7 @@ actual class Factory(
                 name = dbFile.absolutePath,
             ).setDriver(BundledSQLiteDriver())
             .setQueryCoroutineContext(Dispatchers.IO)
-            .fallbackToDestructiveMigration(dropAllTables = true)
+            .addMigrations(MIGRATION_1_2)
             .build()
     }
 

--- a/Fruitties/shared/src/androidMain/kotlin/com/example/fruitties/di/Factory.android.kt
+++ b/Fruitties/shared/src/androidMain/kotlin/com/example/fruitties/di/Factory.android.kt
@@ -34,6 +34,7 @@ actual class Factory(
                 name = dbFile.absolutePath,
             ).setDriver(BundledSQLiteDriver())
             .setQueryCoroutineContext(Dispatchers.IO)
+            .fallbackToDestructiveMigration(dropAllTables = true)
             .build()
     }
 

--- a/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/DataRepository.kt
+++ b/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/DataRepository.kt
@@ -61,10 +61,10 @@ class DataRepository(
     fun getPagingData(): Flow<PagingData<Fruittie>> =
         Pager(
             config = PagingConfig(
-                pageSize = 20,
-                prefetchDistance = 10,
+                pageSize = PAGE_SIZE,
+                prefetchDistance = PREFETCH_DISTANCE,
                 enablePlaceholders = false,
-                initialLoadSize = 20
+                initialLoadSize = INITIAL_LOAD_SIZE,
             ),
             remoteMediator = FruittieRemoteMediator(api, database),
             pagingSourceFactory = { database.fruittieDao().pagingSource() },
@@ -76,4 +76,10 @@ class DataRepository(
         cartDataStore.cart.map { cart ->
             cart.items.find { it.id == id }?.count ?: 0
         }
+
+    companion object {
+        private const val PAGE_SIZE = 20
+        private const val PREFETCH_DISTANCE = 10
+        private const val INITIAL_LOAD_SIZE = 20
+    }
 }

--- a/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/DataRepository.kt
+++ b/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/DataRepository.kt
@@ -15,17 +15,21 @@
  */
 package com.example.fruitties
 
+import androidx.paging.ExperimentalPagingApi
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
 import com.example.fruitties.database.AppDatabase
 import com.example.fruitties.database.CartDataStore
 import com.example.fruitties.model.CartItemDetails
 import com.example.fruitties.model.Fruittie
 import com.example.fruitties.network.FruittieApi
+import com.example.fruitties.paging.FruittieRemoteMediator
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
-import kotlinx.coroutines.launch
 
 class DataRepository(
     private val api: FruittieApi,
@@ -53,14 +57,18 @@ class DataRepository(
         cartDataStore.remove(fruittie)
     }
 
-    fun getData(): Flow<List<Fruittie>> {
-        scope.launch {
-            if (database.fruittieDao().count() < 1) {
-                refreshData()
-            }
-        }
-        return loadData()
-    }
+    @OptIn(ExperimentalPagingApi::class)
+    fun getPagingData(): Flow<PagingData<Fruittie>> =
+        Pager(
+            config = PagingConfig(
+                pageSize = 20,
+                prefetchDistance = 10,
+                enablePlaceholders = false,
+                initialLoadSize = 20
+            ),
+            remoteMediator = FruittieRemoteMediator(api, database),
+            pagingSourceFactory = { database.fruittieDao().pagingSource() },
+        ).flow
 
     suspend fun getFruittie(id: Long): Fruittie? = database.fruittieDao().getFruittie(id)
 
@@ -68,11 +76,4 @@ class DataRepository(
         cartDataStore.cart.map { cart ->
             cart.items.find { it.id == id }?.count ?: 0
         }
-
-    fun loadData(): Flow<List<Fruittie>> = database.fruittieDao().getAllAsFlow()
-
-    suspend fun refreshData() {
-        val response = api.getData()
-        database.fruittieDao().insert(response.feed)
-    }
 }

--- a/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/database/AppDatabase.kt
+++ b/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/database/AppDatabase.kt
@@ -20,11 +20,14 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.RoomDatabaseConstructor
 import com.example.fruitties.model.Fruittie
+import com.example.fruitties.model.RemoteKeys
 
-@Database(entities = [Fruittie::class], version = 1)
+@Database(entities = [Fruittie::class, RemoteKeys::class], version = 2)
 @ConstructedBy(AppDatabaseConstructor::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun fruittieDao(): FruittieDao
+
+    abstract fun remoteKeysDao(): RemoteKeysDao
 }
 
 // The Room compiler generates the `actual` implementations.

--- a/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/database/FruittieDao.kt
+++ b/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/database/FruittieDao.kt
@@ -15,6 +15,7 @@
  */
 package com.example.fruitties.database
 
+import androidx.paging.PagingSource
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.MapColumn
@@ -31,8 +32,14 @@ interface FruittieDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(fruitties: List<Fruittie>)
 
+    @Query("SELECT * FROM Fruittie ORDER BY id DESC")
+    fun pagingSource(): PagingSource<Int, Fruittie>
+
     @Query("SELECT * FROM Fruittie")
     fun getAllAsFlow(): Flow<List<Fruittie>>
+
+    @Query("DELETE FROM Fruittie")
+    suspend fun clearAll()
 
     @Query("SELECT COUNT(*) as count FROM Fruittie")
     suspend fun count(): Int

--- a/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/database/Migrations.kt
+++ b/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/database/Migrations.kt
@@ -1,0 +1,18 @@
+package com.example.fruitties.database
+
+import androidx.room.migration.Migration
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.execSQL
+
+val MIGRATION_1_2 = object : Migration(1, 2) {
+    override fun migrate(connection: SQLiteConnection) {
+        connection.execSQL(
+            "CREATE TABLE IF NOT EXISTS `remote_keys` (`fruittieId` INTEGER NOT NULL, `prevKey` INTEGER, `nextKey` INTEGER, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`fruittieId`))",
+        )
+
+        connection.execSQL("CREATE TABLE IF NOT EXISTS `Fruittie_new` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `fullName` TEXT NOT NULL, `calories` TEXT NOT NULL, PRIMARY KEY(`id`))")
+        connection.execSQL("INSERT INTO `Fruittie_new` (`id`, `name`, `fullName`, `calories`) SELECT `id`, `name`, `fullName`, `calories` FROM `Fruittie`")
+        connection.execSQL("DROP TABLE `Fruittie`")
+        connection.execSQL("ALTER TABLE `Fruittie_new` RENAME TO `Fruittie`")
+    }
+}

--- a/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/database/RemoteKeysDao.kt
+++ b/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/database/RemoteKeysDao.kt
@@ -1,0 +1,19 @@
+package com.example.fruitties.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.example.fruitties.model.RemoteKeys
+
+@Dao
+interface RemoteKeysDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(remoteKey: List<RemoteKeys>)
+
+    @Query("SELECT * FROM remote_keys WHERE fruittieId = :id")
+    suspend fun getRemoteKeyByFruittieId(id: Long): RemoteKeys?
+
+    @Query("DELETE FROM remote_keys")
+    suspend fun clearRemoteKeys()
+}

--- a/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/model/Fruittie.kt
+++ b/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/model/Fruittie.kt
@@ -23,7 +23,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 @Entity
 data class Fruittie(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @PrimaryKey val id: Long = 0,
     @SerialName("name")
     val name: String,
     @SerialName("full_name")

--- a/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/model/RemoteKeys.kt
+++ b/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/model/RemoteKeys.kt
@@ -1,0 +1,15 @@
+package com.example.fruitties.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+@Entity(tableName = "remote_keys")
+data class RemoteKeys @OptIn(ExperimentalTime::class) constructor(
+    @PrimaryKey
+    val fruittieId: Long,
+    val prevKey: Int?,
+    val nextKey: Int?,
+    val createdAt: Long = Clock.System.now().toEpochMilliseconds()
+)

--- a/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/paging/FruittieRemoteMediator.kt
+++ b/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/paging/FruittieRemoteMediator.kt
@@ -1,0 +1,87 @@
+package com.example.fruitties.paging
+
+import androidx.paging.ExperimentalPagingApi
+import androidx.paging.LoadType
+import androidx.paging.PagingState
+import androidx.paging.RemoteMediator
+import com.example.fruitties.database.AppDatabase
+import com.example.fruitties.model.Fruittie
+import com.example.fruitties.model.RemoteKeys
+import com.example.fruitties.network.FruittieApi
+
+@OptIn(ExperimentalPagingApi::class)
+class FruittieRemoteMediator(
+    private val api: FruittieApi,
+    private val database: AppDatabase,
+) : RemoteMediator<Int, Fruittie>() {
+    private val fruittieDao = database.fruittieDao()
+    private val remoteKeysDao = database.remoteKeysDao()
+
+    override suspend fun load(
+        loadType: LoadType,
+        state: PagingState<Int, Fruittie>,
+    ): MediatorResult {
+        return try {
+            val page = when (loadType) {
+                LoadType.REFRESH -> {
+                    val remoteKeys = getRemoteKeyClosestToCurrentPosition(state)
+                    remoteKeys?.nextKey?.minus(1) ?: 0
+                }
+                LoadType.PREPEND -> {
+                    val remoteKeys = getRemoteKeyForFirstItem(state)
+                    val prevKey = remoteKeys?.prevKey
+                        ?: return MediatorResult.Success(endOfPaginationReached = remoteKeys != null)
+                    prevKey
+                }
+                LoadType.APPEND -> {
+                    val remoteKeys = getRemoteKeyForLastItem(state)
+                    val nextKey = remoteKeys?.nextKey
+                        ?: return MediatorResult.Success(endOfPaginationReached = remoteKeys != null)
+                    nextKey
+                }
+            }
+
+            val response = api.getData(page)
+            val fruitties = response.feed
+            val endOfPaginationReached = fruitties.isEmpty() || page >= response.totalPages - 1
+
+            if (loadType == LoadType.REFRESH) {
+                remoteKeysDao.clearRemoteKeys()
+                fruittieDao.clearAll()
+            }
+
+            val prevKey = if (page == 0) null else page - 1
+            val nextKey = if (endOfPaginationReached) null else page + 1
+            val keys = fruitties.map {
+                RemoteKeys(
+                    fruittieId = it.id,
+                    prevKey = prevKey,
+                    nextKey = nextKey,
+                )
+            }
+            remoteKeysDao.insertAll(keys)
+            fruittieDao.insert(fruitties)
+
+            MediatorResult.Success(endOfPaginationReached = endOfPaginationReached)
+        } catch (e: Exception) {
+            MediatorResult.Error(e)
+        }
+    }
+
+    private suspend fun getRemoteKeyClosestToCurrentPosition(state: PagingState<Int, Fruittie>): RemoteKeys? =
+        state.anchorPosition?.let { position ->
+            state.closestItemToPosition(position)?.id?.let { id ->
+                remoteKeysDao.getRemoteKeyByFruittieId(id)
+            }
+        }
+
+    private suspend fun getRemoteKeyForFirstItem(state: PagingState<Int, Fruittie>): RemoteKeys? =
+        state.pages.firstOrNull { it.data.isNotEmpty() }?.data?.firstOrNull()?.let { fruittie ->
+            remoteKeysDao.getRemoteKeyByFruittieId(fruittie.id)
+        }
+
+    private suspend fun getRemoteKeyForLastItem(state: PagingState<Int, Fruittie>): RemoteKeys? =
+        state.pages.lastOrNull { it.data.isNotEmpty() }?.data?.lastOrNull()?.let { fruittie ->
+            remoteKeysDao.getRemoteKeyByFruittieId(fruittie.id)
+        }
+}

--- a/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/paging/FruittieRemoteMediator.kt
+++ b/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/paging/FruittieRemoteMediator.kt
@@ -4,6 +4,8 @@ import androidx.paging.ExperimentalPagingApi
 import androidx.paging.LoadType
 import androidx.paging.PagingState
 import androidx.paging.RemoteMediator
+import androidx.room.immediateTransaction
+import androidx.room.useWriterConnection
 import com.example.fruitties.database.AppDatabase
 import com.example.fruitties.model.Fruittie
 import com.example.fruitties.model.RemoteKeys
@@ -45,11 +47,6 @@ class FruittieRemoteMediator(
             val fruitties = response.feed
             val endOfPaginationReached = fruitties.isEmpty() || page >= response.totalPages - 1
 
-            if (loadType == LoadType.REFRESH) {
-                remoteKeysDao.clearRemoteKeys()
-                fruittieDao.clearAll()
-            }
-
             val prevKey = if (page == 0) null else page - 1
             val nextKey = if (endOfPaginationReached) null else page + 1
             val keys = fruitties.map {
@@ -59,8 +56,17 @@ class FruittieRemoteMediator(
                     nextKey = nextKey,
                 )
             }
-            remoteKeysDao.insertAll(keys)
-            fruittieDao.insert(fruitties)
+
+            database.useWriterConnection {
+                it.immediateTransaction {
+                    if (loadType == LoadType.REFRESH && fruitties.isNotEmpty()) {
+                        remoteKeysDao.clearRemoteKeys()
+                        fruittieDao.clearAll()
+                    }
+                    remoteKeysDao.insertAll(keys)
+                    fruittieDao.insert(fruitties)
+                }
+            }
 
             MediatorResult.Success(endOfPaginationReached = endOfPaginationReached)
         } catch (e: Exception) {

--- a/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/viewmodel/MainViewModel.kt
+++ b/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/viewmodel/MainViewModel.kt
@@ -18,12 +18,15 @@ package com.example.fruitties.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
 import co.touchlab.kermit.Logger
 import com.example.fruitties.DataRepository
 import com.example.fruitties.model.Fruittie
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -39,12 +42,14 @@ class MainViewModel(
         Logger.v { "MainViewModel cleared" }
     }
 
+    val fruittiesPagingData: Flow<PagingData<Fruittie>> =
+        repository.getPagingData().cachedIn(viewModelScope)
+
     val homeUiState: StateFlow<HomeUiState> =
         repository
-            .getData()
-            .combine(repository.cartDetails) { fruitties, cartState ->
+            .cartDetails
+            .map { cartState ->
                 HomeUiState(
-                    fruitties = fruitties,
                     cartItemCount = cartState.sumOf { item -> item.count },
                 )
             }.stateIn(
@@ -64,7 +69,6 @@ class MainViewModel(
  * Ui State for the home screen
  */
 data class HomeUiState(
-    val fruitties: List<Fruittie> = listOf(),
     val cartItemCount: Int = 0,
 )
 

--- a/Fruitties/shared/src/iosMain/kotlin/com/example/fruitties/di/Factory.native.kt
+++ b/Fruitties/shared/src/iosMain/kotlin/com/example/fruitties/di/Factory.native.kt
@@ -36,6 +36,7 @@ actual class Factory {
                 name = dbFile,
             ).setDriver(BundledSQLiteDriver())
             .setQueryCoroutineContext(Dispatchers.IO)
+            .fallbackToDestructiveMigration(dropAllTables = true)
             .build()
     }
 

--- a/Fruitties/shared/src/iosMain/kotlin/com/example/fruitties/di/Factory.native.kt
+++ b/Fruitties/shared/src/iosMain/kotlin/com/example/fruitties/di/Factory.native.kt
@@ -20,6 +20,7 @@ import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import com.example.fruitties.database.AppDatabase
 import com.example.fruitties.database.CartDataStore
 import com.example.fruitties.database.DB_FILE_NAME
+import com.example.fruitties.database.MIGRATION_1_2
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -36,7 +37,7 @@ actual class Factory {
                 name = dbFile,
             ).setDriver(BundledSQLiteDriver())
             .setQueryCoroutineContext(Dispatchers.IO)
-            .fallbackToDestructiveMigration(dropAllTables = true)
+            .addMigrations(MIGRATION_1_2)
             .build()
     }
 


### PR DESCRIPTION
This pull request introduces paging support for the Fruitties app, enabling efficient loading and display of large lists of items on both Android and iOS. The changes include the implementation of the Android Paging 3 library, database and model updates to support remote keys for pagination, and updates to the UI and repository layers to consume paged data. The result is improved performance and scalability when handling large datasets.

**Paging Implementation and Data Flow:**

- Added a `FruittieRemoteMediator` class to coordinate network and database paging, handling loading, appending, and error states for paged data (`Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/paging/FruittieRemoteMediator.kt`).
- Updated the `DataRepository` to provide a `getPagingData()` method returning a `Flow<PagingData<Fruittie>>`, replacing the previous approach of loading all data at once (`Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/DataRepository.kt`).

**Database and Model Changes for Paging:**

- Updated the Room database schema to include a `RemoteKeys` entity and DAO for tracking pagination state, and incremented the database version (`Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/database/AppDatabase.kt`, `Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/database/RemoteKeysDao.kt`, `Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/model/RemoteKeys.kt`) [[1]](diffhunk://#diff-10e1e51e308f593a3f6a4dc31d579223b80866ab30d0024770c587a28ffa49d3R23-R30) [[2]](diffhunk://#diff-b86db28586c91a06344492fea77a97c6ea03824b1d99ce6586a40725a02170e3R1-R19) [[3]](diffhunk://#diff-345dd6a8cd18f3f4bc79c2e8814f7aa70cf7ebe0817e71fed1a6939c785b2819R1-R15).
- Modified `FruittieDao` to add a `pagingSource()` method and support clearing all entries, enabling paging queries (`Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/database/FruittieDao.kt`).

**Android and iOS UI Updates:**

- Refactored the Android `ListScreen` to use `LazyColumn` with paging, displaying loading indicators and error messages as appropriate (`Fruitties/androidApp/src/main/java/com/example/fruitties/android/ui/ListScreen.kt`) [[1]](diffhunk://#diff-27dc5978f9cba9bb29983f543e3473b9524ba07ba837af8486ee1b3e2783536fR72) [[2]](diffhunk://#diff-27dc5978f9cba9bb29983f543e3473b9524ba07ba837af8486ee1b3e2783536fL105-R116) [[3]](diffhunk://#diff-27dc5978f9cba9bb29983f543e3473b9524ba07ba837af8486ee1b3e2783536fR125-R151).
- Updated the iOS `ContentView` to observe and display paged data instead of a static list (`Fruitties/iosApp/iosApp/ui/ContentView.swift`).

**ViewModel and State Changes:**

- Updated `MainViewModel` to expose `fruittiesPagingData` and refactored `HomeUiState` to remove the list of fruitties, as this is now handled by the paging flow (`Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/viewmodel/MainViewModel.kt`) [[1]](diffhunk://#diff-1430c2172d4207474ba43003c9110461d70a11fddd3ff31ee91bdec10af0f1a9R45-L47) [[2]](diffhunk://#diff-1430c2172d4207474ba43003c9110461d70a11fddd3ff31ee91bdec10af0f1a9L67).

**Database Migration Handling:**

- Enabled destructive migrations for both Android and iOS Room database factories to handle schema changes during development (`Fruitties/shared/src/androidMain/kotlin/com/example/fruitties/di/Factory.android.kt`, `Fruitties/shared/src/iosMain/kotlin/com/example/fruitties/di/Factory.native.kt`) [[1]](diffhunk://#diff-ef1de3e4e1d11fdeea02a1a20f8862b67eeef8e6d2405e72916d88c32aac2b8cR37) [[2]](diffhunk://#diff-a2ce9b1ba60e16b5e6d46723a7974667c26f130804275726b1c9339fed9c29e4R39).