### PR TITLE
Added Apache 2.0 license to missing source files

### DIFF
--- a/Fruitties/androidApp/src/main/java/com/example/fruitties/android/ui/FruittieScreen.kt
+++ b/Fruitties/androidApp/src/main/java/com/example/fruitties/android/ui/FruittieScreen.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Android Open Source Project
+ * Copyright 2026 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Fruitties/androidApp/src/main/java/com/example/fruitties/android/ui/FruittieScreen.kt
+++ b/Fruitties/androidApp/src/main/java/com/example/fruitties/android/ui/FruittieScreen.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.example.fruitties.android.ui
 
 import androidx.compose.foundation.layout.Column

--- a/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/viewmodel/FruittieViewModel.kt
+++ b/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/viewmodel/FruittieViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Android Open Source Project
+ * Copyright 2026 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/viewmodel/FruittieViewModel.kt
+++ b/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/viewmodel/FruittieViewModel.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.example.fruitties.viewmodel
 
 import androidx.lifecycle.ViewModel

--- a/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/viewmodel/ViewModelFactory.kt
+++ b/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/viewmodel/ViewModelFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Android Open Source Project
+ * Copyright 2026 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/viewmodel/ViewModelFactory.kt
+++ b/Fruitties/shared/src/commonMain/kotlin/com/example/fruitties/viewmodel/ViewModelFactory.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.example.fruitties.viewmodel
 
 import androidx.lifecycle.viewmodel.MutableCreationExtras

--- a/Fruitties/shared/src/iosMain/kotlin/com/example/fruitties/di/viewmodel/ViewModelStoreUtil.kt
+++ b/Fruitties/shared/src/iosMain/kotlin/com/example/fruitties/di/viewmodel/ViewModelStoreUtil.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Android Open Source Project
+ * Copyright 2026 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Fruitties/shared/src/iosMain/kotlin/com/example/fruitties/di/viewmodel/ViewModelStoreUtil.kt
+++ b/Fruitties/shared/src/iosMain/kotlin/com/example/fruitties/di/viewmodel/ViewModelStoreUtil.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.example.fruitties.di.viewmodel
 
 import androidx.lifecycle.ViewModel


### PR DESCRIPTION
Four Kotlin files were missing the Apache 2.0 license header that every
other source file carries.

- Added the header to FruittieScreen, FruittieViewModel, ViewModelFactory
  and ViewModelStoreUtil.